### PR TITLE
Replace deprecated imp module before Python 3.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.1.0 (not released)
+~~~~~~~~~~~~~~~~~~~~
+
+* Replace deprecated ``imp`` module withh ``importlib`` before it is dropped in
+  Python 3.10. `pep-0594 <https://www.python.org/dev/peps/pep-0594/#imp>`_
+* Drop Python 2 support.
+* Allow ``__FILE__`` builtin with the ``file`` argument to ``execute``.
+
 3.0.0 (not released)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -668,7 +668,8 @@ Keywords:
 
 file
 ~~~~
-Path of the python file to load.
+Path of the python file to load. The ``__FILE__`` builtin to can be used to
+define the file relatively to the main program.
 
 
 module

--- a/examples/backups/backups.py
+++ b/examples/backups/backups.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 
+import os
+import datetime
 import clg
 import yaml
 import yamlordereddictloader
 from pprint import pprint
+
+CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), 'cmd.yml'))
 
 def Date(value):
     try:
@@ -13,7 +17,7 @@ def Date(value):
 clg.TYPES['Date'] = Date
 
 def main():
-    conf = yaml.load(open('cmd.yml'), Loader=yamlordereddictloader.Loader)
+    conf = yaml.load(open(CMD_FILE), Loader=yamlordereddictloader.Loader)
     cmd = clg.CommandLine(conf)
     args = cmd.parse()
     pprint(vars(args))

--- a/examples/builtins/builtins.py
+++ b/examples/builtins/builtins.py
@@ -1,6 +1,8 @@
+import os
 import clg
 import yaml
 
-cmd = clg.CommandLine(yaml.load(open('builtins.yml')))
+CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),'builtins.yml'))
+cmd = clg.CommandLine(yaml.load(open(CMD_FILE), Loader=yaml.SafeLoader))
 args = cmd.parse()
 print(args.sum(args.integers))

--- a/examples/exclusive_groups/exclusive_groups.py
+++ b/examples/exclusive_groups/exclusive_groups.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 import clg
+import os
 import yaml
 
+CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), 'exclusive_groups.yml'))
 def main():
-    cmd = clg.CommandLine(yaml.load(open('exclusive_groups.yml')))
+    with open(CMD_FILE) as o_f:
+        cmd = clg.CommandLine(yaml.load(o_f, Loader=yaml.SafeLoader))
     print(cmd.parse())
 
 if __name__ == '__main__':

--- a/examples/groups/groups.py
+++ b/examples/groups/groups.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 import clg
+import os
 import yaml
 
+CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), 'groups.yml'))
 def main():
-    cmd = clg.CommandLine(yaml.load(open('groups.yml')))
+    with open(CMD_FILE) as o_f:
+        cmd = clg.CommandLine(yaml.load(o_f, Loader=yaml.SafeLoader))
     print(cmd.parse())
 
 

--- a/examples/kvm/cmd.yml
+++ b/examples/kvm/cmd.yml
@@ -185,7 +185,7 @@ subparsers:
         add_help: False
         print_help: True
         execute:
-            module: commands.migrate
+            file: __FILE__/commands/migrate.py
         groups:
             - title: Common options
               options: *MAIN

--- a/examples/kvm/kvm.py
+++ b/examples/kvm/kvm.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-sys.path.append('../..')
 import clg
 import yaml
 import yamlordereddictloader

--- a/examples/ldap/ldap.py
+++ b/examples/ldap/ldap.py
@@ -9,7 +9,7 @@ from pprint import pprint
 CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), 'cmd.yml'))
 
 def main():
-    cmd = clg.CommandLine(yaml.load(open('cmd.yml'), Loader=yamlordereddictloader.Loader))
+    cmd = clg.CommandLine(yaml.load(open(CMD_FILE), Loader=yamlordereddictloader.Loader))
     args = cmd.parse()
     pprint(vars(args))
 

--- a/examples/simple/simple.py
+++ b/examples/simple/simple.py
@@ -2,12 +2,16 @@
 
 import clg
 import json
+import os
 from collections import OrderedDict
 #import yaml
 #import yamlordereddictloader
 
+CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), 'simple.json'))
+# CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), 'simple.yml'))
+
 def main():
-    cmd_conf = json.load(open('simple.json'), object_pairs_hook=OrderedDict)
+    cmd_conf = json.load(open(CMD_FILE), object_pairs_hook=OrderedDict)
 #    cmd_conf = yaml.load(open('simple.yml'), Loader=yamlordereddictloader.Loader)
     cmd = clg.CommandLine(cmd_conf)
     args = cmd.parse()

--- a/examples/subparsers/subparsers.py
+++ b/examples/subparsers/subparsers.py
@@ -1,11 +1,13 @@
 #! /usr/bin/env python
 
 import clg
+import os
 import yaml
 import yamlordereddictloader
 
+CMD_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),'subparsers.yml'))
 def main():
-    cmd = clg.CommandLine(yaml.load(open('subparsers.yml'),
+    cmd = clg.CommandLine(yaml.load(open(CMD_FILE),
                                     Loader=yamlordereddictloader.Loader))
     print(cmd.parse())
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='clg',
-    version='3.0.0',
+    version='3.1.0',
     author='François Ménabé',
     author_email='francois.menabe@gmail.com',
     url='https://clg.readthedocs.org/en/latest/',
@@ -20,9 +20,12 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Utilities'
     ],
     packages=['clg'])


### PR DESCRIPTION
The `imp` module is being dropped soon https://www.python.org/dev/peps/pep-0594/#imp 
This PR replaces it with `importlib` and in the process I made a small change to allow the `__FILE__` builtin with `execute: file`. I also change the `kvm` example to use `execute: file` to see that it worked.

I also dropped Python 2 which I hope isn't too forward. 