### PR TITLE
Add a pyi and py.typed to support typing libraries

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include README.rst
 include LICENSE
+include clg/py.typed
+include clg/*.pyi

--- a/clg/__init__.py
+++ b/clg/__init__.py
@@ -805,7 +805,7 @@ def init(format='yaml', data=os.path.join(sys.path[0], 'cmd.yml'),
     elif format == 'raw':
         config = data
     else:
-        raise CLGError('unsupported format: %s' % format)
+        raise CLGError([], 'unsupported format: %s' % format)
     cmd = CommandLine(config, subcommands_keyword, deepcopy)
 
     # Activate completion if wished.

--- a/clg/__init__.pyi
+++ b/clg/__init__.pyi
@@ -1,0 +1,73 @@
+import argparse
+from typing import Any, Callable, Iterator, NoReturn, Sequence
+
+
+ACTIONS: dict[str, argparse.Action] = ...
+COMPLETERS: dict[str, Callable] = ...
+
+
+class CLGError(Exception):
+    path: list[str]
+    msg: str
+
+    def __init__(self, path: list[str], msg: str) -> None:
+        ...
+
+    def __str__(self) -> str:
+        ...
+
+
+class NoAbbrevParser(argparse.ArgumentParser):
+    ...
+
+
+class HelpPager(argparse.Action):
+    def __init__(self, option_strings: Sequence[str],
+                 dest: str, default: str = ...,
+                 help: str | None = ...
+    ) -> None:
+        ...
+
+    def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
+                 values: str | Sequence[Any] | None, option_string: str | None = ...
+    ) -> None:
+        ...
+
+
+class Namespace(argparse.Namespace):
+    def __init__(self, args: dict[str, Any]) -> None:
+        ...
+
+    def __getitem__(self, key: str) -> Any:
+        ...
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        ...
+
+    def __delitem__(self, key: str) -> None:
+        ...
+
+    def _get(self, key: str, default: Any = ...) -> Any:
+        ...
+
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
+        ...
+
+
+class CommandLine(object):
+    def __init__(
+        self, config: dict[str, Any], keyword: str = ..., deepcopy: bool = ...
+    ) -> None:
+        ...
+    
+    def parse(self, args: Sequence[str] | None = ...) -> Namespace:
+        ...
+    
+    def print_help(self, args: Namespace) -> None:
+        ...
+
+
+def init(format: str = ..., data: str = ...,
+         completion: bool = ..., subcommands_keyword: str = ..., deepcopy: bool = ...
+         ) -> Namespace:
+    ...

--- a/doc/source/installation_and_usage.rst
+++ b/doc/source/installation_and_usage.rst
@@ -5,7 +5,7 @@ Installation and usage
 
 Installation
 ============
-This module is tested with python2.7, python3.4 and python 3.5 (it should work
+This module is tested with python3.4 through python 3.10 (it should work
 for any python3 version). It is on `PyPi <https://pypi.python.org/pypi/clg>`_
 so you can use the ``pip`` command for installing it. If you use YAML for your
 configuration file, you need to install the ``pyyaml`` module too. ``json``

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,10 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Topic :: Utilities'
     ],
+    package_data={
+        # data files need to be listed both here (which determines what gets
+        # installed) and in MANIFEST.in (which determines what gets included
+        # in the sdist tarball)
+        "clg": ["py.typed", "__init__.pyi"],
+    }
     packages=['clg'])


### PR DESCRIPTION
This adds typing to the public methods, and while it supports py3.4 as a minimum we can't add the typing inline in the .py file.

It also updates documentation to say py3.4+

The inclusion of the py.typed file tells downstream projects to use this projects typing definitions.  As such I do recommend a minor ver bump rather than a patch ver bump, since this upgrade could - in theory - have negatives to projects which typecheck.